### PR TITLE
feat: Update codeowners to include sudosubin for people

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-*       @naru200 @eunsukimme
+*                    @eunsukimme @naru200
+/data/people.json    @eunsukimme @naru200 @sudosubin
+/public/people/      @eunsukimme @naru200 @sudosubin


### PR DESCRIPTION
- `.github/CODEOWNERS`를 수정해서 people을 추가, 수정하는 경우 저도 PR을 승인할 수 있도록 변경합니다.
