### PR TITLE
Config ts import alias

### DIFF
--- a/data/people.test.ts
+++ b/data/people.test.ts
@@ -1,4 +1,4 @@
-import peopleJson from 'data/people.json';
+import peopleJson from '@/data/people.json';
 
 interface Person {
   year: string;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,10 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest',
+  projects: ['<rootDir>/'],
+  testRegex: '\\.test\\.(ts|js)x?$',
   testEnvironment: 'node',
   moduleNameMapper: {
-    'data/(.*)$': '<rootDir>/data/$1',
+    '@/data/(.*)$': '<rootDir>/data/$1',
   }
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,8 +4,8 @@ import type { AppProps } from 'next/app';
 import { DefaultSeo } from 'next-seo';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-import { pageview } from '@/lib/gtag';
-import GoogleAnalytics from '@/components/GoogleAnalytics';
+import { pageview } from '@/src/lib/gtag';
+import GoogleAnalytics from '@/src/components/GoogleAnalytics';
 
 function App({ Component, pageProps }: AppProps) {
   const router = useRouter();

--- a/pages/activities/index.tsx
+++ b/pages/activities/index.tsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 import Head from 'next/head';
 import clsx from 'clsx';
 
-import Header from '@/components/Header';
-import AboutBigChat from '@/_pages/Activities/AboutBigChat';
-import AboutStudy from '@/_pages/Activities/AboutStudy';
+import AboutBigChat from '@/src/_pages/Activities/AboutBigChat';
+import AboutStudy from '@/src/_pages/Activities/AboutStudy';
+import Header from '@/src/components/Header';
 
 const Activities = () => {
   const [currentTab, setCurrentTab] = useState<'bigchat' | 'study'>('bigchat');

--- a/pages/contact/index.tsx
+++ b/pages/contact/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import Header from '@/components/Header';
+import Header from '@/src/components/Header';
 import ContactImage from 'public/images/contact.png';
 import Image from 'next/image';
 import Head from 'next/head';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,11 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import BlogSection from '@/_pages/index/components/BlogSection';
-import FAQSection from '@/_pages/index/components/FAQSection';
-import IntroSection from '@/_pages/index/components/IntroSection';
-import MainSection from '@/_pages/index/components/MainSection';
-import MemberSection from '@/_pages/index/components/MemberSection';
-// import SubscribeSection from '@/_pages//index/components/SubscribeSection';
+import BlogSection from '@/src/_pages/index/components/BlogSection';
+import FAQSection from '@/src/_pages/index/components/FAQSection';
+import IntroSection from '@/src/_pages/index/components/IntroSection';
+import MainSection from '@/src/_pages/index/components/MainSection';
+import MemberSection from '@/src/_pages/index/components/MemberSection';
+// import SubscribeSection from '@/src/_pages//index/components/SubscribeSection';
 
 const Home: NextPage = () => (
   <div className="">

--- a/pages/people/index.tsx
+++ b/pages/people/index.tsx
@@ -1,11 +1,10 @@
 import { Fragment } from 'react';
 import Head from 'next/head';
 
-import Header from '@/components/Header';
-import ScrollNavigation from '@/_pages/people/ScrollNavigation';
-import IntroCard from '@/_pages/people/IntroCard';
-
+import Header from '@/src/components/Header';
 import peopleData from 'data/people.json';
+import ScrollNavigation from '@/src/_pages/people/ScrollNavigation';
+import IntroCard from '@/src/_pages/people/IntroCard';
 
 const shuffle = (array: any[], randomNumber: number) => {
   let currentIndex = array.length;

--- a/src/_pages/index/components/BlogSection.tsx
+++ b/src/_pages/index/components/BlogSection.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import Card from '@/components/Card';
+import Card from '@/src/components/Card';
 // import ArrowRightIcon from 'public/icons/arrow_right.svg';
 import React from 'react';
 import ArrowRight from '../../../../public/icons/arrow_right.svg';

--- a/src/_pages/index/components/FAQSection.tsx
+++ b/src/_pages/index/components/FAQSection.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ArrowRightIcon from 'public/icons/arrow_right.svg';
-import Dropdown from '@/components/Dropdown';
-import QUESTIONS from '@/constants/questions';
+import Dropdown from '@/src/components/Dropdown';
+import QUESTIONS from '@/src/constants/questions';
 import Link from 'next/link';
-import { event } from '@/lib/gtag';
+import { event } from '@/src/lib/gtag';
 
 export default function FAQSection() {
   const handleClick = () => {

--- a/src/_pages/index/components/IntroSection.tsx
+++ b/src/_pages/index/components/IntroSection.tsx
@@ -1,4 +1,4 @@
-import Header from '@/components/Header';
+import Header from '@/src/components/Header';
 import React from 'react';
 import CloudImage from 'public/images/cloud.svg';
 import CloudTruncatedImage from 'public/images/cloud-truncated.svg';

--- a/src/_pages/index/components/MemberSection.tsx
+++ b/src/_pages/index/components/MemberSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 // import ArrowRightIcon from 'public/icons/arrow_right.svg';
-import QUOTES from '@/constants/quotes';
+import QUOTES from '@/src/constants/quotes';
 import QuoteCard from './QuoteCard';
 
 export default function MemberSection() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,11 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/src/*": ["src/*"],
+      "@/pages/*": ["pages/*"],
+      "@/public/*": ["public/*"],
+      "@/styles/*": ["styles/*"],
+      "@/data/*": ["data/*"],
     }
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,8 @@
     "**/*.tsx"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx",
   ]
 }


### PR DESCRIPTION
### Summary

Close #66 

- import 경로가 상대경로인 경우가 많이. ts-config와 import 경로를 적절하게 alias로 교체가 필요합니다.
- 우선은 이후에 생기는 코드들은 alias를 사용하도록 하기 위해 설정 먼저 추가합니다.
- 그리고 추후 상대 경로 코드들을 수정하는 것을 차근차근 진행합니다.

### Test


- [x] local에서 화면들 잘 뜨는 걸로 확인!
<img width="1613" alt="image" src="https://github.com/AUSG/2022-homepage/assets/72328687/c9bb24ce-3254-4ac8-a2d6-36355473a645">


