### PR TITLE
ci: upgrade node v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
 
       - name: Install Dependencies


### PR DESCRIPTION
node.js 16버전은 2주 뒤인 9월 11일에 지원 종료될 예정입니다.