### PR TITLE
ci: upgrade checkout v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,6 @@ jobs:
     name: Deploy app
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only


### PR DESCRIPTION
deprecated된 node 12 버전을 사용하고있는 checkout v2 버전을 사용중인것을 node16버전을 사용하는 checkout v3 버전으로 업글합니다.