### PR TITLE
[FIX] 메인 페이지에 있는 멤버 이미지 경로 수정

### DIFF
--- a/src/constants/quotes.ts
+++ b/src/constants/quotes.ts
@@ -4,14 +4,14 @@ const QUOTES = [
       '쉽사리 뵐 수 없는 멋진 분들이 많은 동아리입니다. 그런 분들에게 많이 배우며, 또 그들이 가지고 있는 시야를 함께 가지고 싶어 공부하고 성장하게 되는 건강한 동아리입니다. AUSG 다니고, 나의 성공시대 시작됐다.',
     name: '이태현',
     profile: 'AUSG 7기, 당근마켓 Backend Engineer',
-    imagePath: '/people/taehyun.lee.jpeg',
+    imagePath: '/people/taehyun.lee.jpg',
   },
   {
     content:
       '저는 지식 공유와 함께 성장하는 경험을 좋아해서 AUSG 합류했고 구성원분들 만나 몰입하고 함께하는 시간이 정말 즐거웠어요. 그리고 AUSG에는 지식 공유를 좋아하면서 열정적이고 수준높은 인재들이 함께 있는데요! 이 사람들과 함께 하는 순간순간이 서로에게 자극이 되고 좋은 에너지를 주고받는 시간이었던 것 같습니다 :) 앞으로 AUSG에 함께하실 분들도 이 소중한 경험을 꼭 느껴보셨으면 좋겠어요!',
     name: '김한수',
     profile: 'AUSG 6기, 뱅크샐러드 Server Engineer',
-    imagePath: '/people/mokhs00.jpeg',
+    imagePath: '/people/mokhs00.jpg',
   },
   {
     content:
@@ -32,14 +32,14 @@ const QUOTES = [
       '클라우드에 대한 경험과 지식을 쌓고 싶다면 AUSG를 추천해요. 이전 기수 분들이 클라우드 짱짱맨이셔서 도움을 많이 받았고 AUSG 활동을 통해 많은 것들을 알아가고 경험할 수 있었어요! 클라우드 진로에 대해 고민하고 있다면 AUSG과 함께해도 좋을 것 같아요 :)',
     name: '김수민',
     profile: 'AUSG 6기, AWS Cloud Support Associate, 경희대학교',
-    imagePath: '/people/Eeap.jpeg',
+    imagePath: '/people/Eeap.jpg',
   },
   {
     content:
       '꿈을 위해 무모하게 도전하는 대학생들이 모이는 곳. Cloud라는 관심사 아래 다양하고 구체적인, 가끔은 이상한 경험을 나누는 곳. 여기 AUSG. 낭만적이지 않나요?',
     name: '우수연',
     profile: 'AUSG 4기, IBM Technology Engineer',
-    imagePath: '/people/suyeonwoo.jpeg',
+    imagePath: '/people/suyeonwoo.jpg',
   },
   {
     content:
@@ -88,14 +88,14 @@ const QUOTES = [
       'AUSG에서 다양한 사람들을 많이 만나서 발전한 것 같습니다 :) 우리 AUSG 멤버들을 볼 때 내가 부족한 점과 내가 발전해야 하는 점 등을 항상 느끼고 있어요. 함께 발전해 나아갈 수 있는 엄청난 커뮤니티에 함께 하는 것만으로도 대단한 영광입니다.',
     name: '김민태',
     profile: 'AUSG 4기, 우아한형제들 서버 개발자',
-    imagePath: '/people/connor614.jpeg',
+    imagePath: '/people/connor614.jpg',
   },
   {
     content:
       'AUSG에서 꽤 구체적인 (동시에 한없이 러프한) 관심사를 가진 분들과의 대화를 통해 여러 가지로 느낀 것도 많고 배운 것도 많았습니다. 클라우드와 AWS, 그리고 IT에 관심이 있는 분들은 많이 지원해 주세요!',
     name: '문성혁',
     profile: 'AUSG 3기, 데브시스터즈 DevOps Engineer',
-    imagePath: '/people/roeniss.png',
+    imagePath: '/people/roeniss.jpg',
   },
   {
     content:


### PR DESCRIPTION
지난 업데이트 https://github.com/AUSG/2022-homepage/pull/138 에서 이미지를 압축하면서 이름이 조금씩 바꼈는데 메인페이지에 이미지에는 적용이 안돼서 지금 안뜨더라구욥..

수정했읍니다.