### PR TITLE
프로필 이미지 로드 크기 최적화 및 깨진 quote 이미지 경로 수정

### DIFF
--- a/src/_pages/bigchat/BigchatPage.tsx
+++ b/src/_pages/bigchat/BigchatPage.tsx
@@ -1,6 +1,5 @@
 import { useState, type ReactNode } from 'react';
 import Head from 'next/head';
-import Image from 'next/image';
 import clsx from 'clsx';
 import useEmblaCarousel from 'embla-carousel-react';
 
@@ -11,6 +10,7 @@ import ShareImage from '@/public/images/share.svg';
 import { getPeopleData, type Person } from '@/data/people';
 import videoData from '@/data/videos.json';
 import Header from '@/src/components/Header';
+import ProfileAvatar from '@/src/components/ProfileAvatar';
 import { usePrevNextButtons } from '@/src/_pages/hooks/usePrevNextButton';
 import BigChatBackground from '@/src/_pages/index/components/BigChatBackground';
 import {
@@ -494,24 +494,20 @@ const SpeakerAvatarGroup = ({ speakers }: { speakers: MatchedSpeaker[] }) => {
         keyCounts.set(keyBase, keyCount + 1);
 
         return (
-          <div
+          <ProfileAvatar
             key={`${keyBase}-${keyCount}`}
+            src={
+              item?.person
+                ? `/people/${item.person.photo}`
+                : '/images/profile-1.png'
+            }
+            alt={`${item?.name ?? 'Bigchat speaker'} profile`}
+            size="md"
             className={clsx(
-              'relative h-12 w-12 overflow-hidden rounded-full border-2 border-[#cbd8ff] bg-white md:h-14 md:w-14',
+              'border-2 border-[#cbd8ff] bg-white',
               i > 0 && '-ml-3'
             )}
-          >
-            <Image
-              src={
-                item?.person
-                  ? `/people/${item.person.photo}`
-                  : '/images/profile-1.png'
-              }
-              alt={`${item?.name ?? 'Bigchat speaker'} profile`}
-              layout="fill"
-              objectFit="cover"
-            />
-          </div>
+          />
         );
       })}
     </div>

--- a/src/_pages/index/components/QuoteCard.tsx
+++ b/src/_pages/index/components/QuoteCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import Image from 'next/image';
+
+import ProfileAvatar from '@/src/components/ProfileAvatar';
 import QuoteIcon from 'public/icons/quote.svg';
 
 interface QuoteCardType {
@@ -22,9 +23,12 @@ export default function QuoteCard({
         {content}
       </div>
       <div className="mt-[24px] flex items-center xl:mt-[32px]">
-        <div className="mr-[8px] h-[48px] w-[48px] shrink-0 overflow-hidden rounded-full xl:mr-[30px] xl:h-[60px] xl:w-[60px]">
-          <Image src={imagePath} width="100%" height="100%" alt="" />
-        </div>
+        <ProfileAvatar
+          src={imagePath}
+          alt=""
+          size="sm"
+          className="mr-[8px] xl:mr-[30px]"
+        />
         <div className="text-[14px]">
           <strong>{name}</strong>
           <br />

--- a/src/_pages/people/IntroCard.tsx
+++ b/src/_pages/people/IntroCard.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import Image from 'next/image';
 
+import ProfileAvatar from '@/src/components/ProfileAvatar';
 import QuoteIcon from 'public/icons/quote.svg';
 import GithubIcon from 'public/icons/github.svg';
 import LinkedinIcon from 'public/icons/linkedin.svg';
@@ -40,15 +41,12 @@ const IntroCard: FC<IntroCardProps> = ({
           />
         </div>
       )}
-      <div className="relative mr-3 h-12 flex-shrink-0 basis-12 overflow-hidden rounded-full lg:mr-6 lg:h-24 lg:basis-24 ">
-        <Image
-          src={`/people/${photo}`}
-          alt={`${name_ko}_사진`}
-          width={96}
-          height={96}
-          objectFit="cover"
-        />
-      </div>
+      <ProfileAvatar
+        src={`/people/${photo}`}
+        alt={`${name_ko}_사진`}
+        size="lg"
+        className="mr-3 lg:mr-6"
+      />
       <div>
         <div className="flex items-center">
           <h2 className="mr-3 text-base font-semibold lg:mr-5 lg:text-2xl">

--- a/src/components/ProfileAvatar.tsx
+++ b/src/components/ProfileAvatar.tsx
@@ -1,0 +1,58 @@
+import Image from 'next/image';
+import clsx from 'clsx';
+
+type ProfileAvatarSize = 'sm' | 'md' | 'lg';
+
+const avatarSizeConfig: Record<
+  ProfileAvatarSize,
+  { className: string; sizes: string }
+> = {
+  sm: {
+    className: 'h-[48px] w-[48px] xl:h-[60px] xl:w-[60px]',
+    sizes: '(min-width: 1280px) 60px, 48px',
+  },
+  md: {
+    className: 'h-12 w-12 md:h-14 md:w-14',
+    sizes: '(min-width: 768px) 56px, 48px',
+  },
+  lg: {
+    className: 'h-12 w-12 lg:h-24 lg:w-24',
+    sizes: '(min-width: 1024px) 96px, 48px',
+  },
+};
+
+interface ProfileAvatarProps {
+  src: string;
+  alt: string;
+  size?: ProfileAvatarSize;
+  className?: string;
+}
+
+const ProfileAvatar = ({
+  src,
+  alt,
+  size = 'md',
+  className,
+}: ProfileAvatarProps) => {
+  const sizeConfig = avatarSizeConfig[size];
+
+  return (
+    <div
+      className={clsx(
+        'relative shrink-0 overflow-hidden rounded-full',
+        sizeConfig.className,
+        className
+      )}
+    >
+      <Image
+        src={src}
+        alt={alt}
+        layout="fill"
+        objectFit="cover"
+        sizes={sizeConfig.sizes}
+      />
+    </div>
+  );
+};
+
+export default ProfileAvatar;

--- a/src/constants/quotes.ts
+++ b/src/constants/quotes.ts
@@ -90,7 +90,7 @@ const QUOTES = [
       '꿈을 위해 무모하게 도전하는 대학생들이 모이는 곳. Cloud라는 관심사 아래 다양하고 구체적인, 가끔은 이상한 경험을 나누는 곳. 여기 AUSG. 낭만적이지 않나요?',
     name: '우수연',
     profile: 'AUSG 4기, IBM Technology Engineer',
-    imagePath: '/people/suyeonwoo.jpg',
+    imagePath: '/people/SuyeonWoo.jpg',
   },
   {
     content:


### PR DESCRIPTION
## 작업 내용

- 프로필 이미지를 렌더링하는 공통 `ProfileAvatar` 컴포넌트를 추가했습니다.
- Bigchat, People, 메인 quote 카드의 프로필 이미지 렌더링 방식을 `ProfileAvatar`로 통일했습니다.
- `next/image`의 `layout="fill"` 사용 시 실제 렌더링 크기에 맞는 `sizes`를 명시하도록 정리했습니다.
- 메인 quote에 사용되는 우수연 님 이미지 경로를 존재하지 않는 `/people/suyeonwoo.jpg`에서 `/people/SuyeonWoo.jpg`로 수정했습니다.

## 배경

Bigchat 탭의 speaker avatar는 실제로는 약 48-56px 크기로 렌더링되지만, `next/image`에서 `layout="fill"`을 사용하면서 `sizes`가 지정되어 있지 않아 브라우저가 이미지를 `100vw` 기준으로 선택하고 있었습니다.

그 결과 작은 프로필 이미지임에도 다음과 같은 과도한 이미지 요청이 발생할 수 있었습니다.

```txt
/_next/image?url=/people/{photo}&w=3840&q=75
```

이 요청이 여러 개 동시에 발생하면서 이미지 로드가 느려지거나, 일부 환경에서 502 / broken image가 발생할 수 있었습니다.

## 수정 방향

프로필 이미지는 페이지마다 개별적으로 `next/image`를 직접 사용하는 대신, 공통 `ProfileAvatar` 컴포넌트를 통해 렌더링하도록 정리했습니다.

크기별로 실제 렌더링 사이즈와 `sizes` 값을 함께 관리합니다.

```txt
sm: 48px / xl 60px
md: 48px / md 56px
lg: 48px / lg 96px
```

이를 통해 브라우저가 avatar 이미지에 대해 `w=3840` 같은 과도한 후보를 선택하지 않고, 실제 렌더링 크기에 맞는 이미지 리소스를 선택하도록 했습니다.

## 확인 사항

- Bigchat 탭 speaker avatar가 `w=128` 정도의 적절한 이미지로 요청되는 것을 확인했습니다.
- People 페이지 avatar는 기존처럼 `w=256` 정도의 이미지로 요청되는 것을 확인했습니다.
- 메인 quote avatar는 `w=128` 정도의 이미지로 요청되는 것을 확인했습니다.
- `/people/SuyeonWoo.jpg` 경로가 정상 응답하는 것을 확인했습니다.
- quote 이미지 경로들이 로컬 public 파일에 존재하는지 확인했습니다.

## 테스트

```txt
npm run lint
npx tsc --noEmit
npm test -- --runInBand
npm run build
```

`npm run lint`와 `npm run build`에서 기존 lint warning은 남아 있지만, 이번 변경으로 인한 오류는 없습니다.