### PR TITLE
ci: compress activity images in pull requests

### DIFF
--- a/.github/workflows/ci-compress-image.yml
+++ b/.github/workflows/ci-compress-image.yml
@@ -6,6 +6,9 @@ on:
       - public/people/*.jpg
       - public/people/*.jpeg
       - public/people/*.png
+      - public/activities/*.jpg
+      - public/activities/*.jpeg
+      - public/activities/*.png
 
 jobs:
   ci:


### PR DESCRIPTION
- Activities 이미지도 PR에서 자동 압축되도록 CI 대상에 추가했습니다.
  - `public/activities/*` 추가