### PR TITLE
feat: 300KB 초과 이미지 PR 경고 workflow 추가

### DIFF
--- a/.github/workflows/ci-image-size-check.yml
+++ b/.github/workflows/ci-image-size-check.yml
@@ -1,0 +1,83 @@
+name: Image Size Check
+
+on:
+  pull_request:
+    paths:
+      - 'public/**/*.jpg'
+      - 'public/**/*.jpeg'
+      - 'public/**/*.png'
+      - 'public/**/*.JPG'
+      - 'public/**/*.PNG'
+      - 'public/**/*.gif'
+      - 'public/**/*.webp'
+
+jobs:
+  check:
+    name: Check Image Size
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Find large images
+        id: find
+        run: |
+          THRESHOLD=307200  # 300KB in bytes
+
+          LARGE_FILES=""
+          while IFS= read -r -d '' file; do
+            size=$(stat -c%s "$file")
+            if [ "$size" -ge "$THRESHOLD" ]; then
+              size_kb=$((size / 1024))
+              LARGE_FILES="${LARGE_FILES}\n| \`${file}\` | ${size_kb}KB |"
+            fi
+          done < <(find public -type f \( \
+            -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \
+            -o -iname "*.gif" -o -iname "*.webp" \
+          \) -print0)
+
+          if [ -n "$LARGE_FILES" ]; then
+            echo "found=true" >> $GITHUB_OUTPUT
+            {
+              echo "table<<EOF"
+              printf "%b" "$LARGE_FILES"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Comment on PR
+        if: steps.find.outputs.found == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const table = `${{ steps.find.outputs.table }}`;
+            const body = [
+              '## ⚠️ 300KB 초과 이미지 감지',
+              '',
+              '다음 이미지 파일이 300KB를 초과합니다. WebP 변환 또는 리사이즈를 권장합니다.',
+              '',
+              '| 파일 | 크기 |',
+              '|------|------|',
+              table,
+              '',
+              '**권장 조치:**',
+              '- WebP 변환 (quality 80~85): `cwebp -q 85 input.jpg -o output.webp`',
+              '- 또는 리사이즈 후 재압축: `magick input.jpg -resize 1600x1600> -quality 82 output.jpg`',
+              '',
+              '**원본 보관:**',
+              '변환 전 원본은 `archived/originals/` 하위에 동일한 경로 구조로 보관해 주세요.',
+              '예) `public/people/foo.jpg` → `archived/originals/people/foo.jpg`',
+              '',
+              '> 강제 사항은 아닙니다. 단, 큰 이미지는 페이지 로딩 속도에 영향을 줄 수 있습니다.',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/.github/workflows/ci-image-size-check.yml
+++ b/.github/workflows/ci-image-size-check.yml
@@ -26,17 +26,19 @@ jobs:
         run: |
           THRESHOLD=307200  # 300KB in bytes
 
+          # PR에서 추가/수정된 파일만 대상
+          CHANGED=$(git diff --name-only --diff-filter=AM origin/${{ github.base_ref }}...HEAD)
+
           LARGE_FILES=""
-          while IFS= read -r -d '' file; do
+          while IFS= read -r file; do
+            [[ "$file" =~ \.(jpg|jpeg|png|JPG|PNG|gif|webp)$ ]] || continue
+            [ -f "$file" ] || continue
             size=$(stat -c%s "$file")
             if [ "$size" -ge "$THRESHOLD" ]; then
               size_kb=$((size / 1024))
               LARGE_FILES="${LARGE_FILES}\n| \`${file}\` | ${size_kb}KB |"
             fi
-          done < <(find public -type f \( \
-            -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" \
-            -o -iname "*.gif" -o -iname "*.webp" \
-          \) -print0)
+          done <<< "$CHANGED"
 
           if [ -n "$LARGE_FILES" ]; then
             echo "found=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 요약

PR에 300KB 초과 이미지가 포함될 경우 자동으로 경고 코멘트를 남기는 workflow 추가.

## 동작

1. `public/**` 하위 이미지 파일(jpg/jpeg/png/gif/webp)이 변경된 PR에서 트리거
2. PR에서 **추가/수정된 파일만** 대상으로 300KB 초과 여부 검사
3. 초과 파일이 있으면 PR에 코멘트:
   - 초과 파일 목록 (파일명 + 크기)
   - WebP 변환 / 리사이즈 명령어 예시
   - `archived/originals/` 원본 보관 권장 안내
4. 초과 파일 없으면 조용히 종료

## 특이사항

- 강제성 없음 (CI 통과/실패 여부에 영향 없음)
- 기존 파일이나 삭제된 파일은 검사 대상에서 제외
- 기존 `ci-compress-image.yml` 과 역할 분리: 기존은 자동 압축, 이건 안내만