### PR TITLE
fix: Activities 이미지를 정적 파일로 직접 서빙하도록 변경

### DIFF
--- a/src/_pages/Activities/ActivityImage.tsx
+++ b/src/_pages/Activities/ActivityImage.tsx
@@ -1,5 +1,5 @@
+/* eslint-disable @next/next/no-img-element */
 import { useState } from 'react';
-import Image from 'next/image';
 
 import { onPhotoContextMenu, photoPath, PHOTO_PLACEHOLDER } from './utils';
 
@@ -10,7 +10,6 @@ interface ActivityImageProps {
   objectPosition?: string;
   priority?: boolean;
   loading?: 'eager' | 'lazy';
-  sizes: string;
 }
 
 const ActivityImage = ({
@@ -20,21 +19,15 @@ const ActivityImage = ({
   objectPosition,
   priority = false,
   loading,
-  sizes,
 }: ActivityImageProps) => {
   const [src, setSrc] = useState(photoPath(file));
 
   return (
-    <Image
+    <img
       src={src}
       alt={alt}
-      layout="fill"
-      objectFit="cover"
-      objectPosition={objectPosition}
-      sizes={sizes}
-      quality={78}
-      priority={priority}
-      loading={loading}
+      loading={loading ?? (priority ? 'eager' : 'lazy')}
+      decoding="async"
       onError={() =>
         setSrc(current =>
           current === PHOTO_PLACEHOLDER ? current : PHOTO_PLACEHOLDER
@@ -43,6 +36,7 @@ const ActivityImage = ({
       onContextMenu={onPhotoContextMenu}
       draggable={false}
       className={className}
+      style={objectPosition ? { objectPosition } : undefined}
     />
   );
 };

--- a/src/_pages/Activities/CoffeechatSection.tsx
+++ b/src/_pages/Activities/CoffeechatSection.tsx
@@ -56,7 +56,6 @@ const CoffeechatSection = () => {
                     file={pair.photo}
                     alt=""
                     className="h-full w-full object-cover"
-                    sizes="(min-width: 1024px) 33vw, (min-width: 768px) 33vw, 50vw"
                   />
                 </div>
               </div>

--- a/src/_pages/Activities/GlobalSection.tsx
+++ b/src/_pages/Activities/GlobalSection.tsx
@@ -24,7 +24,6 @@ const Slide = ({ photo, priority = false, loading }: SlideProps) => {
       className="h-full w-full object-cover"
       priority={priority}
       loading={loading}
-      sizes="(min-width: 1024px) 56vw, 100vw"
     />
   );
 

--- a/src/_pages/Activities/TechStudySection.tsx
+++ b/src/_pages/Activities/TechStudySection.tsx
@@ -28,11 +28,6 @@ const TrackCard = ({ track, large }: TrackCardProps) => (
         file={track.photo}
         alt={track.title}
         className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
-        sizes={
-          large
-            ? '(min-width: 1024px) 50vw, (min-width: 768px) 50vw, 100vw'
-            : '(min-width: 1024px) 25vw, (min-width: 768px) 50vw, 100vw'
-        }
       />
       <div className="absolute inset-0 bg-gradient-to-t from-gray-900/80 via-gray-900/10 to-transparent" />
       <div className="absolute inset-x-5 bottom-5">

--- a/src/_pages/Activities/WarmUpSection.tsx
+++ b/src/_pages/Activities/WarmUpSection.tsx
@@ -86,7 +86,6 @@ const WarmUpSection = () => {
                           ? photo.objectPosition
                           : undefined
                       }
-                      sizes="(min-width: 1024px) 38vw, (min-width: 768px) 50vw, 80vw"
                     />
                   </div>
                   <figcaption className="mt-3 flex items-baseline justify-between gap-3 text-white/80">


### PR DESCRIPTION
## 작업 내용

- `ActivityImage`에서 `next/image` 사용을 제거하고 일반 `<img>` 태그 기반 렌더링으로 변경했습니다.
- Activities 이미지가 `/_next/image` optimizer 경로를 타지 않고 `/activities/*` 정적 파일로 직접 요청되도록 했습니다.
- `next/image` 전용 prop이었던 `sizes` 사용을 Activities 호출부에서 제거했습니다.
- 기존 fallback 이미지 처리, 우클릭 방지, `objectPosition`, lazy/eager loading 동작은 유지했습니다.

## 배경

현재 Activities 이미지는 PR #229에서 WebP 변환 및 리사이즈를 통해 사전 최적화된 상태입니다.

하지만 `ActivityImage`가 `next/image`를 사용하면서 배포 서버에서는 여전히 다음과 같은 런타임 image optimizer 요청이 발생했습니다.

```txt
/_next/image?url=/activities/{file}&w={width}&q=78
```

이 요청은 단순 정적 파일 서빙이 아니라 Next 서버가 이미지를 읽고, 디코딩하고, 리사이즈/재인코딩하는 경로입니다.

Fly.io free tier 환경에서는 이미지 optimizer 요청이 동시에 발생할 때 connection이 오래 유지되며 다음과 같은 로그가 발생할 수 있었습니다.

```txt
reached hard limit of 25 concurrent connections
```

이미 Activities 이미지는 사전 압축된 정적 asset으로 관리되고 있으므로, 런타임 image optimizer를 한 번 더 거치는 것보다 정적 파일을 직접 서빙하는 쪽이 운영 안정성에 더 적합하다고 판단했습니다.

## 수정 방향

Before:

```txt
/_next/image?url=/activities/global00.webp&w=1920&q=78
```

After:

```txt
/activities/global00.webp
```

일반 `<img>` 태그를 사용하되 다음 동작은 유지했습니다.

- `loading="lazy"` 기본 적용
- Global 캐러셀의 eager 이미지 로딩 유지
- `decoding="async"` 적용
- 이미지 로드 실패 시 activities placeholder로 fallback
- `objectPosition` 반영
- 이미지 우클릭 방지 유지

## Scope

이번 변경은 `/activities` 이미지에만 적용했습니다.

`ProfileAvatar`는 `/people`, `/bigchat`, 메인 quote의 작은 프로필 이미지 전용이며, 이번 Fly.io connection limit 이슈와 직접적으로 연결된 다중 activity 이미지 로딩과 성격이 달라 변경하지 않았습니다.

## 확인 사항

로컬 브라우저에서 `/activities`를 확인했습니다.

- Activities 이미지 요청 중 `/_next/image` 요청 0개 확인
- `/activities/*` 정적 파일 직접 요청 확인
- desktop/mobile viewport에서 broken image 없음
- Global 캐러셀 7장 eager, 나머지 Activities 이미지는 lazy 유지 확인

## 테스트

```txt
npm run lint
npx tsc --noEmit
npm test -- --runInBand
npm run build
git diff --check
```

`npm run lint`와 `npm run build`에서 기존 warning은 남아 있지만, 이번 변경으로 인한 오류는 없습니다.