### PR TITLE
ci: fly.io 배포를 Vercel 배포로 교체

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,8 @@
-name: Fly Deploy
+name: Vercel Deploy
 on:
   push:
     branches:
       - main
-env:
-  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 concurrency:
   group: deploy
   cancel-in-progress: false
@@ -15,5 +13,10 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v3
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - run: npx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - run: npx vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
  - 배포 플랫폼을 fly.io에서 Vercel로 교체
  - FLY_API_TOKEN 제거, VERCEL_TOKEN secret 사용으로 변경
  - Vercel CLI(vercel pull → vercel build → vercel deploy)를 통한 프로덕션 배포

  ## 배포 전 체크리스트
  - [x] GitHub Secrets에 VERCEL_TOKEN 추가
  - [x] Vercel 대시보드에서 ausg.me 도메인 추가
  - [x] GoDaddy DNS 레코드 교체 (fly.io → Vercel)
  - [x] 정상 배포 확인