### PR TITLE
fix(ci): Image Size Check의 GITHUB_OUTPUT heredoc 깨짐 수정

### DIFF
--- a/.github/workflows/ci-image-size-check.yml
+++ b/.github/workflows/ci-image-size-check.yml
@@ -38,7 +38,7 @@ jobs:
             size=$(stat -c%s "$file")
             if [ "$size" -ge "$THRESHOLD" ]; then
               size_kb=$((size / 1024))
-              LARGE_FILES="${LARGE_FILES}\n| \`${file}\` | ${size_kb}KB |"
+              LARGE_FILES="${LARGE_FILES}| \`${file}\` | ${size_kb}KB |"$'\n'
             fi
           done <<< "$CHANGED"
 
@@ -46,7 +46,7 @@ jobs:
             echo "found=true" >> $GITHUB_OUTPUT
             {
               echo "table<<EOF"
-              printf "%b" "$LARGE_FILES"
+              printf "%s" "$LARGE_FILES"
               echo "EOF"
             } >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## 문제

[실패한 워크플로우 실행](https://github.com/AUSG/2022-homepage/actions/runs/26813178023/job/79048193114)

`Image Size Check` 워크플로우의 `Find large images` 스텝이 다음 에러로 실패:
- `Invalid value. Matching delimiter not found 'EOF'`
- `Unable to process file command 'output' successfully.`

## 원인

`$GITHUB_OUTPUT`에 멀티라인 값을 heredoc(`table<<EOF ... EOF`)으로 쓸 때:
- `printf "%b" "$LARGE_FILES"`가 **끝에 줄바꿈을 출력하지 않아**, 바로 뒤의 `echo "EOF"`가 마지막 표 행에 붙어 `... |EOF`가 됨 → 종료 구분자 `EOF`가 독립된 줄로 인식되지 않아 실패.
- 또한 누적 변수가 `${LARGE_FILES}\n| ... |` 형태라 값 맨 앞에 빈 줄이 생겨, 댓글 마크다운 표가 깨짐.

이 버그는 **300KB 초과 이미지가 PR에 포함될 때만** 재현됩니다. (#240에서 추가된 `main_x3.png`(417KB)가 처음으로 조건을 충족시켜 드러남)

## 수정

- 누적 시 리터럴 `\n` 대신 **실제 줄바꿈**(`$'\n'`)을 사용
- 출력은 `printf "%s"`로 변경 → 값이 줄바꿈으로 끝나 `EOF`가 단독 줄이 되고, 표 앞 빈 줄도 사라짐

## 검증

로컬에서 동일 로직을 시뮬레이션해 `$GITHUB_OUTPUT` 출력이 아래처럼 나오는 것 확인 (`EOF` 단독 줄, 표 앞 빈 줄 없음):

```
table<<EOF
| public/images/main_x3.png | 407KB |
EOF
```
