### PR TITLE
ci: Compress Image 대상에 public/images/ 포함

### DIFF
--- a/.github/workflows/ci-compress-image.yml
+++ b/.github/workflows/ci-compress-image.yml
@@ -9,9 +9,6 @@ on:
       - public/activities/*.jpg
       - public/activities/*.jpeg
       - public/activities/*.png
-      - public/images/*.jpg
-      - public/images/*.jpeg
-      - public/images/*.png
       - public/images/**/*.jpg
       - public/images/**/*.jpeg
       - public/images/**/*.png

--- a/.github/workflows/ci-compress-image.yml
+++ b/.github/workflows/ci-compress-image.yml
@@ -9,6 +9,12 @@ on:
       - public/activities/*.jpg
       - public/activities/*.jpeg
       - public/activities/*.png
+      - public/images/*.jpg
+      - public/images/*.jpeg
+      - public/images/*.png
+      - public/images/**/*.jpg
+      - public/images/**/*.jpeg
+      - public/images/**/*.png
 
 jobs:
   ci:
@@ -22,4 +28,4 @@ jobs:
         uses: calibreapp/image-actions@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          ignorePaths: "public/icons/**,public/images/**,public/*"
+          ignorePaths: "public/icons/**,public/*"


### PR DESCRIPTION
## 배경

`Compress Image` 워크플로우([calibreapp/image-actions](https://github.com/calibreapp/image-actions))는 PR에 포함된 이미지를 자동 압축하지만, 지금까지 `public/people/`·`public/activities/`만 대상이었고 `public/images/**`는 트리거에서도 빠지고 `ignorePaths`로도 제외되어 있었습니다.

그래서 메인 히어로 이미지(`public/images/main_x3.png`) 같은 파일은 자동 압축되지 않아, `Image Size Check`(300KB)에 걸리는 상황이 발생했습니다. (관련: #240, #241)

## 변경

- `on.pull_request.paths`에 `public/images/`의 직속 및 하위 `jpg`·`jpeg`·`png` 추가
- `ignorePaths`에서 `public/images/**` 제거 (`public/icons/**`, `public/*`는 유지)

이제 `public/images/` 하위 래스터 이미지도 PR 시 자동으로 압축됩니다.

## 참고

- 이 액션은 **압축(최적화)** 위주이며 픽셀 리사이즈는 하지 않습니다.
- `public/icons/**`(아이콘)과 `public/*`(public 직속 파일)은 기존대로 제외 유지.
