### PR TITLE
feat: 메인 플레이리스트 헤딩을 YouTube 플레이리스트 링크로 변경

### DIFF
--- a/src/_pages/index/components/BlogSection.tsx
+++ b/src/_pages/index/components/BlogSection.tsx
@@ -1,3 +1,5 @@
+import ArrowRightIcon from 'public/icons/arrow_right.svg';
+
 export default function BlogSection() {
   return (
     <div className="bg-primary">
@@ -8,14 +10,20 @@ export default function BlogSection() {
         </h1>
         <section className="space-evenly mt-6 flex flex-col gap-[16px] md:flex-row xl:mt-12 xl:gap-[48px]">
           <div className="flex basis-[50%] flex-col">
-            <a
-              href="https://www.youtube.com/playlist?list=PLzE5CrlMM0CDLVzxgir4Kbj7oPBD4VUvC"
-              target="_blank"
-              rel="noreferrer"
-              className="w-fit pb-4 text-[20px] font-bold text-white hover:underline md:text-2xl"
-            >
-              BigChat 발표영상 플레이리스트
-            </a>
+            <div className="flex items-center justify-between gap-3 pb-4">
+              <span className="min-w-0 text-[20px] font-bold text-white md:text-2xl">
+                BigChat 발표영상 플레이리스트
+              </span>
+              <a
+                href="https://www.youtube.com/playlist?list=PLzE5CrlMM0CDLVzxgir4Kbj7oPBD4VUvC"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex shrink-0 items-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-semibold text-primary transition-colors hover:bg-white/90"
+              >
+                전체 영상 보기
+                <ArrowRightIcon className="h-4 w-4 fill-primary" />
+              </a>
+            </div>
 
             {/* ref for dynamic youtube iframe sizing : https://stackoverflow.com/a/54924505/8556340 */}
             <div className="relative mx-auto h-0 w-full pb-[56.25%]">
@@ -31,14 +39,20 @@ export default function BlogSection() {
             </div>
           </div>
           <div className="flex basis-[50%] flex-col">
-            <a
-              href="https://www.youtube.com/playlist?list=PLzE5CrlMM0CC2zMxggs4GasLICq5dKDqW"
-              target="_blank"
-              rel="noreferrer"
-              className="w-fit pb-4 text-[20px] font-bold text-white hover:underline md:text-2xl"
-            >
-              AUSGCON 발표영상 플레이리스트
-            </a>
+            <div className="flex items-center justify-between gap-3 pb-4">
+              <span className="min-w-0 text-[20px] font-bold text-white md:text-2xl">
+                AUSGCON 발표영상 플레이리스트
+              </span>
+              <a
+                href="https://www.youtube.com/playlist?list=PLzE5CrlMM0CC2zMxggs4GasLICq5dKDqW"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex shrink-0 items-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-semibold text-primary transition-colors hover:bg-white/90"
+              >
+                전체 영상 보기
+                <ArrowRightIcon className="h-4 w-4 fill-primary" />
+              </a>
+            </div>
 
             <div className="relative mx-auto h-0 w-full pb-[56.25%]">
               <iframe

--- a/src/_pages/index/components/BlogSection.tsx
+++ b/src/_pages/index/components/BlogSection.tsx
@@ -8,9 +8,14 @@ export default function BlogSection() {
         </h1>
         <section className="space-evenly mt-6 flex flex-col gap-[16px] md:flex-row xl:mt-12 xl:gap-[48px]">
           <div className="flex basis-[50%] flex-col">
-            <span className="pb-4 text-[20px] font-bold text-white  md:text-2xl">
+            <a
+              href="https://www.youtube.com/playlist?list=PLzE5CrlMM0CDLVzxgir4Kbj7oPBD4VUvC"
+              target="_blank"
+              rel="noreferrer"
+              className="w-fit pb-4 text-[20px] font-bold text-white hover:underline md:text-2xl"
+            >
               BigChat 발표영상 플레이리스트
-            </span>
+            </a>
 
             {/* ref for dynamic youtube iframe sizing : https://stackoverflow.com/a/54924505/8556340 */}
             <div className="relative mx-auto h-0 w-full pb-[56.25%]">
@@ -26,9 +31,14 @@ export default function BlogSection() {
             </div>
           </div>
           <div className="flex basis-[50%] flex-col">
-            <span className="pb-4 text-[20px] font-bold text-white  md:text-2xl">
+            <a
+              href="https://www.youtube.com/playlist?list=PLzE5CrlMM0CC2zMxggs4GasLICq5dKDqW"
+              target="_blank"
+              rel="noreferrer"
+              className="w-fit pb-4 text-[20px] font-bold text-white hover:underline md:text-2xl"
+            >
               AUSGCON 발표영상 플레이리스트
-            </span>
+            </a>
 
             <div className="relative mx-auto h-0 w-full pb-[56.25%]">
               <iframe


### PR DESCRIPTION
## 변경

메인 페이지(`BlogSection`)의 두 플레이리스트 헤딩 텍스트를 해당 YouTube **플레이리스트 링크**로 변경했습니다.

- `BigChat 발표영상 플레이리스트` → https://www.youtube.com/playlist?list=PLzE5CrlMM0CDLVzxgir4Kbj7oPBD4VUvC
- `AUSGCON 발표영상 플레이리스트` → https://www.youtube.com/playlist?list=PLzE5CrlMM0CC2zMxggs4GasLICq5dKDqW

`<span>` → `<a>`로 변경(`target="_blank" rel="noreferrer"`, 기존 외부 링크 컨벤션 준수). `w-fit`으로 텍스트 영역만 클릭되게, `hover:underline`로 클릭 가능함을 표시.

## 배경 (관련: #149)

#149는 iPhone+Chrome에서 임베드 플레이어 우측 상단의 **네이티브 목록(햄버거) 아이콘이 간헐적으로 안 보여**, 플레이리스트임을 인지하거나 전체 목록으로 진입하기 어렵다는 버그입니다. 그 아이콘은 YouTube 플레이어가 그리는 것이라 우리 코드로 직접 고칠 수 없습니다.

이 PR은 헤딩 텍스트 자체를 플레이리스트 링크로 만들어, **네이티브 아이콘 표시 여부와 무관하게 항상 플레이리스트 전체로 진입**할 수 있게 하는 우회책입니다. (YouTube 아이콘 자체의 간헐적 미표시 현상은 그대로일 수 있음 → 완전 해결이 아니라 접근성 보완)

## 검증

- `npx eslint` 통과 (exit 0)
- `npx tsc --noEmit` — 관련 에러 없음

---

- close https://github.com/AUSG/ausg.me/issues/149