### PR TITLE
fix: 공진성 프로필 갱신 (GitHub 계정 변경, 링크드인 추가)

### DIFF
--- a/data/people.json
+++ b/data/people.json
@@ -474,8 +474,8 @@
       "name_en": "Jinseong Kong",
       "photo": "jinseong.jpg",
       "short_bio": "끊임없이 우물밖을 탐구하는 개구리",
-      "github_username": "kkardd",
-      "homepage_url": "https://kkardd.github.io"
+      "github_username": "kkardy",
+      "linkedin_username": "kkardy"
     },
     {
       "year": "8th",


### PR DESCRIPTION
## 변경 사항

8기 공진성 프로필 정보를 갱신합니다.

- `github_username`: `kkardd` → `kkardy` (GitHub 계정 변경)
- `homepage_url` 제거 (더 이상 운영하지 않음)
- `linkedin_username`: `kkardy` 추가 (https://www.linkedin.com/in/kkardy)

## 검토자가 알아야 할 사항

- `data/people.json` 데이터만 수정했으며, 코드 변경은 없습니다.
- 링크드인 필드는 기존 컨벤션(`linkedin_username`, `/in/` 뒤 값)을 따랐습니다.
